### PR TITLE
Fix "os: process already finished" not being acknowledged dead

### DIFF
--- a/lockfile.go
+++ b/lockfile.go
@@ -55,7 +55,7 @@ func (l Lockfile) GetOwner() (*os.Process, error) {
 		}
 		errno, ok := err.(syscall.Errno)
 		if !ok {
-			return nil, err
+			return nil, ErrDeadOwner
 		}
 
 		switch errno {


### PR DESCRIPTION
On unix systems, if you try to signal a process that has finished, it will result in an error. Previously, lockfile did not acknowledge this error as the process being dead.

https://golang.org/src/os/exec_unix.go#L37

Since the error is private I can't make a case for the individual error, but by just looking at the function it's clear that the only time it would throw an error (that is not from a syscall) would be if the process is dead.