### PR TITLE
Use GetExitCodeProcess syscall on Windows

### DIFF
--- a/lockfile.go
+++ b/lockfile.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"syscall"
 )
 
 type Lockfile string
@@ -49,23 +48,7 @@ func (l Lockfile) GetOwner() (*os.Process, error) {
 		if err != nil {
 			return nil, err
 		}
-		err = p.Signal(os.Signal(syscall.Signal(0)))
-		if err == nil {
-			return p, nil
-		}
-		errno, ok := err.(syscall.Errno)
-		if !ok {
-			return nil, ErrDeadOwner
-		}
-
-		switch errno {
-		case syscall.ESRCH:
-			return nil, ErrDeadOwner
-		case syscall.EPERM:
-			return p, nil
-		default:
-			return nil, err
-		}
+		return p, isProcessAlive(p)
 	} else {
 		return nil, ErrInvalidPid
 	}

--- a/lockfile_unix.go
+++ b/lockfile_unix.go
@@ -1,0 +1,28 @@
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+
+package lockfile
+
+import (
+	"os"
+	"syscall"
+)
+
+func isProcessAlive(p *os.Process) error {
+	err := p.Signal(os.Signal(syscall.Signal(0)))
+	if err == nil {
+		return nil
+	}
+	errno, ok := err.(syscall.Errno)
+	if !ok {
+		return ErrDeadOwner
+	}
+
+	switch errno {
+	case syscall.ESRCH:
+		return ErrDeadOwner
+	case syscall.EPERM:
+		return nil
+	default:
+		return err
+	}
+}

--- a/lockfile_windows.go
+++ b/lockfile_windows.go
@@ -1,0 +1,32 @@
+package lockfile
+
+import (
+	"os"
+	"reflect"
+	"syscall"
+)
+
+func isProcessAlive(p *os.Process) error {
+	// Extract handle value from the os.Process struct to avoid the need
+	// of a second, manually opened process handle.
+	value := reflect.ValueOf(p)
+	// Dereference *os.Process to os.Process
+	value = value.Elem()
+	field := value.FieldByName("handle")
+
+	handle := syscall.Handle(field.Uint())
+
+	var code uint32
+	err := syscall.GetExitCodeProcess(handle, &code)
+	if err != nil {
+		return err
+	}
+
+	// code will contain the exit code of the process or 259 (STILL_ALIVE)
+	// if the process has not exited yet.
+	if code == 259 {
+		return nil
+	}
+
+	return ErrDeadOwner
+}


### PR DESCRIPTION
Sending signals (except for the Kill signal) is not supported on
Windows right now, so we need to fall back to the Windows-specific
GetExitCodeProcess syscall in order to get the status of a process.