### PR TITLE
Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+clone_folder: c:\gopath\src\github.com\Acconut\lockfile
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - go version
+  - go env
+  - go get -v -t ./...
+
+build_script:
+  - go test -v ./...

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-clone_folder: c:\gopath\src\github.com\Acconut\lockfile
+clone_folder: c:\gopath\src\github.com\nightlyone\lockfile
 
 environment:
   GOPATH: c:\gopath


### PR DESCRIPTION
As discussed in #7 this PR adds the basic instructions to enable testing on AppVeyor. In order to finish the setup, you need to sign up for their service and connect this repository, similar to the flow on Travis CI.