### PR TITLE
Add a prefix for the lock hard links

### DIFF
--- a/lockfile.go
+++ b/lockfile.go
@@ -93,7 +93,7 @@ func (l Lockfile) TryLock() error {
 		panic(ErrNeedAbsPath)
 	}
 
-	tmplock, err := ioutil.TempFile(filepath.Dir(name), "")
+	tmplock, err := ioutil.TempFile(filepath.Dir(name), filepath.Base(name)+".")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
To know to which lock the file is referring to.

For a `test.lock` file, the created links will be `test.lock.XXX`.