### PR TITLE
Suggest retry if lockfile disappears

### DIFF
--- a/lockfile.go
+++ b/lockfile.go
@@ -139,6 +139,10 @@ func (l Lockfile) TryLock() error {
 	proc, err := l.GetOwner()
 	switch err {
 	default:
+		if os.IsNotExist(err) {
+			// tell user that a retry would be a good idea
+			return ErrNotExist
+		}
 		// Other errors -> defensively fail and let caller handle this
 		return err
 	case nil:


### PR DESCRIPTION
I saw very occasional failures like `open /tmp/ignite-snapshot.lock: no such file or directory"`, and suspect it could be here.

Seems possible if the lock file was present when we do the `Lstat()`, but has been removed by the time we get to reading it.

I considered re-doing the `switch` so this would be a case at top level, but went for minimal lines changed. Let me know if you prefer something else.